### PR TITLE
feat: add basic deployment info and local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ The required steps to develop and test the dApp interface locally are as follows
 
 1. Clone the repository: i.e. Run `git clone git@github.com:bosonprotocol/interface.git`
 2. Navigate into the directory & install dependencies: i.e. Run `cd interface && npm ci` 
-3. Build & start the application: i.e. Run `npm run build && npm run dev`
-4. Navigate to `http://localhost:3000/` in a browser.
+3. Copy the `.env.example` file to `.env` and fill out any necessary values.
+4. Start the application: i.e. Run `npm run dev`
+5. Navigate to `http://localhost:3000/` in a browser.


### PR DESCRIPTION
Deployment section is subject to change as we define the environments across the Core Components and dApp - this is WIP with @dennisfurrer and will be available in Asana by following [`Workstreams -> Core Components -> Solution -> Environments for Core Components`](https://www.notion.so/redeemeum/Environments-for-Core-Components-dApp-0e3e77e38e714da7a6401cc35f4f709f)