### PR TITLE
fix: the graph ipfs storage handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@bosonprotocol/chat-sdk": "1.0.2-alpha.4",
-        "@bosonprotocol/react-kit": "^0.4.1",
+        "@bosonprotocol/react-kit": "^0.4.2-alpha.1",
         "@bosonprotocol/widgets-sdk": "^1.9.0",
         "@davatar/react": "^1.10.4",
         "@ethersproject/address": "^5.6.1",
@@ -1914,9 +1914,9 @@
       }
     },
     "node_modules/@bosonprotocol/common": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/common/-/common-1.10.1.tgz",
-      "integrity": "sha512-XZ40NiGI7PSB4mYRVErjgPUB2Ky3QkPoYKUhE1qUBGfuAJL1l0OioJTzG7Nvbl6pN30ACL0nBQ/BF3DMacq7+w==",
+      "version": "1.10.2-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/common/-/common-1.10.2-alpha.1.tgz",
+      "integrity": "sha512-zHrtfWsRlxHlkjXZ9MqZ2Bzg4o+Vhe0NQU4Vi3s+poejAu5NvfzhfvDPveMMl3aV4WSgarfKukACYQy616bSKw==",
       "dependencies": {
         "@bosonprotocol/metadata": "^1.3.1",
         "@ethersproject/abi": "^5.5.0",
@@ -1928,11 +1928,11 @@
       }
     },
     "node_modules/@bosonprotocol/core-sdk": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/core-sdk/-/core-sdk-1.12.6.tgz",
-      "integrity": "sha512-ZI5WXxTOVMEEyOZ5rb/S3IXLoAU12QHc3/YI/nocKPIBom6GPDGQ+MqEQPdyUbBoAbVYz1csG4NM6J3LxVlGMg==",
+      "version": "1.12.7-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/core-sdk/-/core-sdk-1.12.7-alpha.1.tgz",
+      "integrity": "sha512-O7lljgYW1VvPy1RhhYFbV1anRgq+IHwYrKmCft/iZ1o5Q9SH76Y8Hs0IJBHqfeAPL1qwMreogyfSymPhQsKqqg==",
       "dependencies": {
-        "@bosonprotocol/common": "^1.10.1",
+        "@bosonprotocol/common": "^1.10.2-alpha.1",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
@@ -1947,20 +1947,20 @@
       }
     },
     "node_modules/@bosonprotocol/ethers-sdk": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/ethers-sdk/-/ethers-sdk-1.6.6.tgz",
-      "integrity": "sha512-fe2y/lN7W1LHg+EzTmMpN4D351Pu+pduHwweaHFsN6//hFDQ+bLMj0w1A814VVo2iyewL8O3KLXMoBgd0kivJg==",
+      "version": "1.6.7-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/ethers-sdk/-/ethers-sdk-1.6.7-alpha.1.tgz",
+      "integrity": "sha512-rwDdjFuJG2C8LJ/p/YoqWr1NTKYS7ZRJvpD8UoCIR1h3YL/AfLoUkyULaM5sEkmr6/OsmH1jDo3+3gvcSKWlog==",
       "dependencies": {
-        "@bosonprotocol/common": "^1.10.1"
+        "@bosonprotocol/common": "^1.10.2-alpha.1"
       },
       "peerDependencies": {
         "ethers": "^5.5.0"
       }
     },
     "node_modules/@bosonprotocol/ipfs-storage": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/ipfs-storage/-/ipfs-storage-1.7.0.tgz",
-      "integrity": "sha512-dQBPpJ8mva9XK5dljsvmR91dkRK/IqB4oUZFfPMs3gkHg6qr29lPRVdL73HySx8FLTCVY7tAkbGc4UV4u+Cg4Q==",
+      "version": "1.7.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/ipfs-storage/-/ipfs-storage-1.7.1-alpha.1.tgz",
+      "integrity": "sha512-E4ZB/nr3Y4lR34ftYptO0hmbd7YvNBeGoXcNnK2CAIpiceXlxlnvHDkITKJyiT7+aUVQJ6yhQK+gsXeQug8RaQ==",
       "dependencies": {
         "@bosonprotocol/metadata": "^1.3.1",
         "ipfs-http-client": "^56.0.1",
@@ -1977,14 +1977,14 @@
       }
     },
     "node_modules/@bosonprotocol/react-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/react-kit/-/react-kit-0.4.1.tgz",
-      "integrity": "sha512-AjLyJzjNAf5mLgVZ18lL3TAIwfuBfH/F8spJadI7Z2OTziy/7Za+NLWRS95noht9BbTUFen86UFzsRvYMKNJWw==",
+      "version": "0.4.2-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/react-kit/-/react-kit-0.4.2-alpha.1.tgz",
+      "integrity": "sha512-mYVR3edtTQ87tF/sGSnxfnkkotA/u7AeJknN2pzY8U3bvOivC/GsCTQdbagVNtS7o+m3klxFZEAf5vq/pLqCDw==",
       "dependencies": {
         "@biconomy/mexa": "^2.0.32",
-        "@bosonprotocol/core-sdk": "^1.12.6",
-        "@bosonprotocol/ethers-sdk": "^1.6.6",
-        "@bosonprotocol/ipfs-storage": "^1.7.0",
+        "@bosonprotocol/core-sdk": "^1.12.7-alpha.1",
+        "@bosonprotocol/ethers-sdk": "^1.6.7-alpha.1",
+        "@bosonprotocol/ipfs-storage": "^1.7.1-alpha.1",
         "@ethersproject/units": "^5.6.0",
         "@web3-react/core": "8.0.18-beta.0",
         "styled-components": "^5.3.5",
@@ -3258,18 +3258,18 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@ipld/dag-cbor": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.2.tgz",
-      "integrity": "sha512-V9EhJVWXqzjjRs0kiZfUXOaq8y6R2C4AAmfGoMeszqGOBgfACr5tFAgAwZY0e8z/OpmJWpCrZhzPRTZV0c/gjA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
       "dependencies": {
         "cborg": "^1.6.0",
         "multiformats": "^9.5.4"
       }
     },
     "node_modules/@ipld/dag-json": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.10.tgz",
-      "integrity": "sha512-fny24vxVtgAv7aKmAikZq86kikp56knZL/77eyXUsrgGRGtkx9D1awemKbhIVw/7S5nBbP43m/AZwxNPVpP5eg==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
+      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
       "dependencies": {
         "cborg": "^1.5.4",
         "multiformats": "^9.5.4"
@@ -28941,9 +28941,9 @@
       }
     },
     "@bosonprotocol/common": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/common/-/common-1.10.1.tgz",
-      "integrity": "sha512-XZ40NiGI7PSB4mYRVErjgPUB2Ky3QkPoYKUhE1qUBGfuAJL1l0OioJTzG7Nvbl6pN30ACL0nBQ/BF3DMacq7+w==",
+      "version": "1.10.2-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/common/-/common-1.10.2-alpha.1.tgz",
+      "integrity": "sha512-zHrtfWsRlxHlkjXZ9MqZ2Bzg4o+Vhe0NQU4Vi3s+poejAu5NvfzhfvDPveMMl3aV4WSgarfKukACYQy616bSKw==",
       "requires": {
         "@bosonprotocol/metadata": "^1.3.1",
         "@ethersproject/abi": "^5.5.0",
@@ -28955,11 +28955,11 @@
       }
     },
     "@bosonprotocol/core-sdk": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/core-sdk/-/core-sdk-1.12.6.tgz",
-      "integrity": "sha512-ZI5WXxTOVMEEyOZ5rb/S3IXLoAU12QHc3/YI/nocKPIBom6GPDGQ+MqEQPdyUbBoAbVYz1csG4NM6J3LxVlGMg==",
+      "version": "1.12.7-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/core-sdk/-/core-sdk-1.12.7-alpha.1.tgz",
+      "integrity": "sha512-O7lljgYW1VvPy1RhhYFbV1anRgq+IHwYrKmCft/iZ1o5Q9SH76Y8Hs0IJBHqfeAPL1qwMreogyfSymPhQsKqqg==",
       "requires": {
-        "@bosonprotocol/common": "^1.10.1",
+        "@bosonprotocol/common": "^1.10.2-alpha.1",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
@@ -28974,17 +28974,17 @@
       }
     },
     "@bosonprotocol/ethers-sdk": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/ethers-sdk/-/ethers-sdk-1.6.6.tgz",
-      "integrity": "sha512-fe2y/lN7W1LHg+EzTmMpN4D351Pu+pduHwweaHFsN6//hFDQ+bLMj0w1A814VVo2iyewL8O3KLXMoBgd0kivJg==",
+      "version": "1.6.7-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/ethers-sdk/-/ethers-sdk-1.6.7-alpha.1.tgz",
+      "integrity": "sha512-rwDdjFuJG2C8LJ/p/YoqWr1NTKYS7ZRJvpD8UoCIR1h3YL/AfLoUkyULaM5sEkmr6/OsmH1jDo3+3gvcSKWlog==",
       "requires": {
-        "@bosonprotocol/common": "^1.10.1"
+        "@bosonprotocol/common": "^1.10.2-alpha.1"
       }
     },
     "@bosonprotocol/ipfs-storage": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/ipfs-storage/-/ipfs-storage-1.7.0.tgz",
-      "integrity": "sha512-dQBPpJ8mva9XK5dljsvmR91dkRK/IqB4oUZFfPMs3gkHg6qr29lPRVdL73HySx8FLTCVY7tAkbGc4UV4u+Cg4Q==",
+      "version": "1.7.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/ipfs-storage/-/ipfs-storage-1.7.1-alpha.1.tgz",
+      "integrity": "sha512-E4ZB/nr3Y4lR34ftYptO0hmbd7YvNBeGoXcNnK2CAIpiceXlxlnvHDkITKJyiT7+aUVQJ6yhQK+gsXeQug8RaQ==",
       "requires": {
         "@bosonprotocol/metadata": "^1.3.1",
         "ipfs-http-client": "^56.0.1",
@@ -29001,14 +29001,14 @@
       }
     },
     "@bosonprotocol/react-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/react-kit/-/react-kit-0.4.1.tgz",
-      "integrity": "sha512-AjLyJzjNAf5mLgVZ18lL3TAIwfuBfH/F8spJadI7Z2OTziy/7Za+NLWRS95noht9BbTUFen86UFzsRvYMKNJWw==",
+      "version": "0.4.2-alpha.1",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/react-kit/-/react-kit-0.4.2-alpha.1.tgz",
+      "integrity": "sha512-mYVR3edtTQ87tF/sGSnxfnkkotA/u7AeJknN2pzY8U3bvOivC/GsCTQdbagVNtS7o+m3klxFZEAf5vq/pLqCDw==",
       "requires": {
         "@biconomy/mexa": "^2.0.32",
-        "@bosonprotocol/core-sdk": "^1.12.6",
-        "@bosonprotocol/ethers-sdk": "^1.6.6",
-        "@bosonprotocol/ipfs-storage": "^1.7.0",
+        "@bosonprotocol/core-sdk": "^1.12.7-alpha.1",
+        "@bosonprotocol/ethers-sdk": "^1.6.7-alpha.1",
+        "@bosonprotocol/ipfs-storage": "^1.7.1-alpha.1",
         "@ethersproject/units": "^5.6.0",
         "@web3-react/core": "8.0.18-beta.0",
         "styled-components": "^5.3.5",
@@ -29796,18 +29796,18 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "@ipld/dag-cbor": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.2.tgz",
-      "integrity": "sha512-V9EhJVWXqzjjRs0kiZfUXOaq8y6R2C4AAmfGoMeszqGOBgfACr5tFAgAwZY0e8z/OpmJWpCrZhzPRTZV0c/gjA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
+      "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
       "requires": {
         "cborg": "^1.6.0",
         "multiformats": "^9.5.4"
       }
     },
     "@ipld/dag-json": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.10.tgz",
-      "integrity": "sha512-fny24vxVtgAv7aKmAikZq86kikp56knZL/77eyXUsrgGRGtkx9D1awemKbhIVw/7S5nBbP43m/AZwxNPVpP5eg==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
+      "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
       "requires": {
         "cborg": "^1.5.4",
         "multiformats": "^9.5.4"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@bosonprotocol/chat-sdk": "1.0.2-alpha.4",
-    "@bosonprotocol/react-kit": "^0.4.1",
+    "@bosonprotocol/react-kit": "^0.4.2-alpha.1",
     "@bosonprotocol/widgets-sdk": "^1.9.0",
     "@davatar/react": "^1.10.4",
     "@ethersproject/address": "^5.6.1",

--- a/src/components/detail/DetailSlider.tsx
+++ b/src/components/detail/DetailSlider.tsx
@@ -1,6 +1,5 @@
 import "@glidejs/glide/dist/css/glide.core.min.css";
 
-import { IpfsMetadataStorage } from "@bosonprotocol/react-kit";
 import Glide from "@glidejs/glide";
 import { CaretLeft, CaretRight } from "phosphor-react";
 import { useEffect, useRef, useState } from "react";
@@ -9,7 +8,7 @@ import Button from "../../components/ui/Button";
 import Grid from "../../components/ui/Grid";
 import Image from "../../components/ui/Image";
 import Typography from "../../components/ui/Typography";
-import { CONFIG } from "../../lib/config";
+import { useIpfsStorage } from "../../lib/utils/hooks/useIpfsStorage";
 import { SLIDER_OPTIONS } from "./const";
 import { GlideSlide, GlideWrapper } from "./Detail.style";
 
@@ -25,6 +24,7 @@ let glide: any = null;
 export default function DetailSlider({ images, isPreview = false }: Props) {
   const [sliderImages, setSliderImages] = useState<Array<string>>([]);
   const ref = useRef();
+  const ipfsMetadataStorage = useIpfsStorage();
 
   useEffect(() => {
     if (sliderImages.length !== 0 && ref.current) {
@@ -36,11 +36,6 @@ export default function DetailSlider({ images, isPreview = false }: Props) {
   }, [ref, sliderImages]);
 
   const fetchData = async (images: Array<string>) => {
-    const ipfsMetadataStorage = IpfsMetadataStorage.fromTheGraphIpfsUrl({
-      url: CONFIG.ipfsMetadataUrl,
-      headers: CONFIG.ipfsMetadataStorageHeaders
-    });
-
     const fetchPromises = images.map(
       async (src) => await ipfsMetadataStorage.get(src, false)
     );

--- a/src/components/ui/Image.tsx
+++ b/src/components/ui/Image.tsx
@@ -1,12 +1,11 @@
-import { IpfsMetadataStorage } from "@bosonprotocol/react-kit";
 import { CameraSlash, Image as ImageIcon } from "phosphor-react";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import { buttonText } from "../../components/ui/styles";
-import { CONFIG } from "../../lib/config";
 import { colors } from "../../lib/styles/colors";
 import { zIndex } from "../../lib/styles/zIndex";
+import { useIpfsStorage } from "../../lib/utils/hooks/useIpfsStorage";
 import Typography from "./Typography";
 
 const ImageWrapper = styled.div`
@@ -81,14 +80,10 @@ const Image: React.FC<IImage & React.HTMLAttributes<HTMLDivElement>> = ({
   ...rest
 }) => {
   const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const ipfsMetadataStorage = useIpfsStorage();
 
   useEffect(() => {
     async function fetchData(src: string) {
-      const ipfsMetadataStorage = IpfsMetadataStorage.fromTheGraphIpfsUrl({
-        url: CONFIG.ipfsMetadataUrl,
-        headers: CONFIG.ipfsMetadataStorageHeaders
-      });
-
       const fetchPromises = await ipfsMetadataStorage.get(src, false);
       const [image] = await Promise.all([fetchPromises]);
       setImageSrc(String(image));

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -26,6 +26,8 @@ export const CONFIG = {
   },
   widgetsUrl: process.env.REACT_APP_WIDGETS_URL || config.widgetsUrl,
   chainId: REACT_APP_CHAIN_ID,
+  theGraphIpfsUrl:
+    process.env.REACT_APP_THE_GRAPH_IPFS_URL || config.theGraphIpfsUrl,
   ipfsMetadataStorageUrl:
     process.env.REACT_APP_IPFS_METADATA_URL || config.ipfsMetadataUrl,
   ipfsMetadataStorageHeaders: getIpfsMetadataStorageHeaders(


### PR DESCRIPTION
This bumps up the default config package to use the correct
The Graph IPFS API url. That url is not the same in public environments
(mumbai, ropsten, etc.) as our IPFS node (!).

This also fixes the CORS error that was resulting from the above, that was causes
due to incorrect handling of headers when connecting to the IPFS node of the graph.