### PR TITLE
feat: add a link to the contractual Agreement page from the license p…

### DIFF
--- a/src/pages/license/License.tsx
+++ b/src/pages/license/License.tsx
@@ -5,6 +5,7 @@ import { LinkWithQuery } from "../../components/customNavigation/LinkWithQuery";
 import LicenseComponent from "../../components/license/License";
 import Typography from "../../components/ui/Typography";
 import { UrlParameters } from "../../lib/routing/parameters";
+import { BosonRoutes } from "../../lib/routing/routes";
 import useOfferByUuid from "../../lib/utils/hooks/product/useOfferByUuid";
 
 const Container = styled.div`
@@ -37,7 +38,10 @@ export default function License() {
       <Typography tag="p">
         Click&nbsp;
         <LinkWithQuery
-          to={`/contractualAgreement/${offerId}`}
+          to={BosonRoutes.ContractualAgreement.replace(
+            `:${UrlParameters.offerId}`,
+            offerId
+          )}
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
…age (for the given offer)

See [BP406]: https://app.asana.com/0/1200803815983047/1203135553280372
To test it: 
- run the dapp on testing env
- open the page http://localhost:3333/#/license/1665426096214
  (note: the current offer uuid 1665426096214 has been found using the subgraph explorer)
