### PR TITLE
feat: integrate pending tx hook with existing CTAs from react-kit

### DIFF
--- a/src/components/detail/DetailWidget/DetailWidget.tsx
+++ b/src/components/detail/DetailWidget/DetailWidget.tsx
@@ -23,6 +23,7 @@ import { IPrice } from "../../../lib/utils/convertPrice";
 import { titleCase } from "../../../lib/utils/formatText";
 import { getDateTimestamp } from "../../../lib/utils/getDateTimestamp";
 import { getBuyerCancelPenalty } from "../../../lib/utils/getPrices";
+import { useAddPendingTransaction } from "../../../lib/utils/hooks/transactions/usePendingTransactions";
 import { useBreakpoints } from "../../../lib/utils/hooks/useBreakpoints";
 import { useBuyerSellerAccounts } from "../../../lib/utils/hooks/useBuyerSellerAccounts";
 import { Exchange } from "../../../lib/utils/hooks/useExchanges";
@@ -260,6 +261,7 @@ const DetailWidget: React.FC<IDetailWidget> = ({
   ] = useState(false);
   const { showModal, hideModal, modalTypes } = useModal();
   const coreSDK = useCoreSDK();
+  const addPendingTransaction = useAddPendingTransaction();
   const { isLteXS } = useBreakpoints();
   const navigate = useKeepQueryParamsNavigate();
   const { address } = useAccount();
@@ -588,10 +590,19 @@ const DetailWidget: React.FC<IDetailWidget> = ({
                     setIsLoading(true);
                     showModal("WAITING_FOR_CONFIRMATION");
                   }}
-                  onPendingTransaction={(hash) => {
+                  onPendingTransaction={(hash, isMetaTx) => {
                     showModal("TRANSACTION_SUBMITTED", {
                       action: "Commit",
                       txHash: hash
+                    });
+                    addPendingTransaction({
+                      type: subgraph.EventType.BuyerCommitted,
+                      hash,
+                      isMetaTx,
+                      accountType: "Buyer",
+                      offer: {
+                        id: offer.id
+                      }
                     });
                   }}
                   onSuccess={async (_, { exchangeId }) => {

--- a/src/components/modal/components/Chat/CancelExchangeModal.tsx
+++ b/src/components/modal/components/Chat/CancelExchangeModal.tsx
@@ -1,4 +1,4 @@
-import { CancelButton, Provider } from "@bosonprotocol/react-kit";
+import { CancelButton, Provider, subgraph } from "@bosonprotocol/react-kit";
 import { Info as InfoComponent } from "phosphor-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
@@ -8,6 +8,7 @@ import { useSigner } from "wagmi";
 import { CONFIG } from "../../../../lib/config";
 import { colors } from "../../../../lib/styles/colors";
 import { getBuyerCancelPenalty } from "../../../../lib/utils/getPrices";
+import { useAddPendingTransaction } from "../../../../lib/utils/hooks/transactions/usePendingTransactions";
 import { Exchange } from "../../../../lib/utils/hooks/useExchanges";
 import { useCoreSDK } from "../../../../lib/utils/useCoreSdk";
 import { poll } from "../../../../pages/create-product/utils";
@@ -107,6 +108,7 @@ export default function CancelExchangeModal({
   reload
 }: Props) {
   const coreSDK = useCoreSDK();
+  const addPendingTransaction = useAddPendingTransaction();
   const { offer } = exchange;
   const { data: signer } = useSigner();
   const { showModal, modalTypes } = useModal();
@@ -204,10 +206,19 @@ export default function CancelExchangeModal({
               setCancelError(null);
               showModal("WAITING_FOR_CONFIRMATION");
             }}
-            onPendingTransaction={(hash) => {
+            onPendingTransaction={(hash, isMetaTx) => {
               showModal("TRANSACTION_SUBMITTED", {
                 action: "Cancel",
                 txHash: hash
+              });
+              addPendingTransaction({
+                type: subgraph.EventType.VoucherCanceled,
+                hash,
+                isMetaTx,
+                accountType: "Buyer",
+                exchange: {
+                  id: exchange.id
+                }
               });
             }}
             onSuccess={async (_, { exchangeId }) => {

--- a/src/components/modal/components/CompleteExchange.tsx
+++ b/src/components/modal/components/CompleteExchange.tsx
@@ -1,7 +1,8 @@
 import {
   BatchCompleteButton,
   CompleteButton,
-  Provider
+  Provider,
+  subgraph
 } from "@bosonprotocol/react-kit";
 import { BigNumberish } from "ethers";
 import { useCallback, useMemo } from "react";
@@ -11,6 +12,7 @@ import { useSigner } from "wagmi";
 
 import { CONFIG } from "../../../lib/config";
 import { Offer } from "../../../lib/types/offer";
+import { useAddPendingTransaction } from "../../../lib/utils/hooks/transactions/usePendingTransactions";
 import { Exchange } from "../../../lib/utils/hooks/useExchanges";
 import { useCoreSDK } from "../../../lib/utils/useCoreSdk";
 import { poll } from "../../../pages/create-product/utils";
@@ -98,6 +100,7 @@ export default function CompleteExchange({
   refetch
 }: Props) {
   const coreSdk = useCoreSDK();
+  const addPendingTransaction = useAddPendingTransaction();
   const { data: signer } = useSigner();
   const { hideModal, showModal } = useModal();
 
@@ -232,10 +235,19 @@ export default function CompleteExchange({
             onPendingSignature={() => {
               showModal("WAITING_FOR_CONFIRMATION");
             }}
-            onPendingTransaction={(hash) => {
+            onPendingTransaction={(hash, isMetaTx) => {
               showModal("TRANSACTION_SUBMITTED", {
                 action: "Complete",
                 txHash: hash
+              });
+              addPendingTransaction({
+                type: subgraph.EventType.ExchangeCompleted,
+                hash,
+                isMetaTx,
+                accountType: "Seller",
+                exchange: {
+                  id: exchange.id
+                }
               });
             }}
             onSuccess={(receipt) => {
@@ -271,10 +283,23 @@ export default function CompleteExchange({
             onPendingSignature={() => {
               showModal("WAITING_FOR_CONFIRMATION");
             }}
-            onPendingTransaction={(hash) => {
+            onPendingTransaction={(hash, isMetaTx) => {
               showModal("TRANSACTION_SUBMITTED", {
                 action: "Complete",
                 txHash: hash
+              });
+              exchanges.forEach((exchange) => {
+                if (exchange) {
+                  addPendingTransaction({
+                    type: subgraph.EventType.ExchangeCompleted,
+                    hash,
+                    isMetaTx,
+                    accountType: "Seller",
+                    exchange: {
+                      id: exchange.id
+                    }
+                  });
+                }
               });
             }}
             onSuccess={(receipt) => {

--- a/src/components/modal/components/RevokeProduct.tsx
+++ b/src/components/modal/components/RevokeProduct.tsx
@@ -1,10 +1,11 @@
-import { Provider, RevokeButton } from "@bosonprotocol/react-kit";
+import { Provider, RevokeButton, subgraph } from "@bosonprotocol/react-kit";
 import toast from "react-hot-toast";
 import styled from "styled-components";
 import { useSigner } from "wagmi";
 
 import { CONFIG } from "../../../lib/config";
 import { colors } from "../../../lib/styles/colors";
+import { useAddPendingTransaction } from "../../../lib/utils/hooks/transactions/usePendingTransactions";
 import { Exchange } from "../../../lib/utils/hooks/useExchanges";
 import { useCoreSDK } from "../../../lib/utils/useCoreSdk";
 import { poll } from "../../../pages/create-product/utils";
@@ -51,6 +52,7 @@ export default function RevokeProduct({
   const { data: signer } = useSigner();
   const { showModal, hideModal } = useModal();
   const coreSDK = useCoreSDK();
+  const addPendingTransaction = useAddPendingTransaction();
 
   const convertedPrice = useConvertedPrice({
     value: exchange?.offer?.price,
@@ -145,10 +147,19 @@ export default function RevokeProduct({
             onPendingSignature={() => {
               showModal("WAITING_FOR_CONFIRMATION");
             }}
-            onPendingTransaction={(hash) => {
+            onPendingTransaction={(hash, isMetaTx) => {
               showModal("TRANSACTION_SUBMITTED", {
                 action: "Revoke",
                 txHash: hash
+              });
+              addPendingTransaction({
+                type: subgraph.EventType.VoucherRevoked,
+                hash,
+                isMetaTx,
+                accountType: "Seller",
+                exchange: {
+                  id: exchange.id
+                }
               });
             }}
             onSuccess={async (receipt, { exchangeId }) => {

--- a/src/components/modal/components/VoidProduct.tsx
+++ b/src/components/modal/components/VoidProduct.tsx
@@ -1,4 +1,4 @@
-import { Provider, VoidButton } from "@bosonprotocol/react-kit";
+import { Provider, subgraph, VoidButton } from "@bosonprotocol/react-kit";
 import { BigNumberish } from "ethers";
 import { useCallback, useState } from "react";
 import toast from "react-hot-toast";
@@ -8,6 +8,7 @@ import { useSigner } from "wagmi";
 import { CONFIG } from "../../../lib/config";
 import { colors } from "../../../lib/styles/colors";
 import { Offer } from "../../../lib/types/offer";
+import { useAddPendingTransaction } from "../../../lib/utils/hooks/transactions/usePendingTransactions";
 import { useCoreSDK } from "../../../lib/utils/useCoreSdk";
 import { poll } from "../../../pages/create-product/utils";
 import { Break } from "../../detail/Detail.style";
@@ -147,6 +148,7 @@ export default function VoidProduct({
 }: Props) {
   const { showModal } = useModal();
   const coreSdk = useCoreSDK();
+  const addPendingTransaction = useAddPendingTransaction();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { data: signer } = useSigner();
   const { hideModal } = useModal();
@@ -292,10 +294,19 @@ export default function VoidProduct({
               onPendingSignature={() => {
                 showModal("WAITING_FOR_CONFIRMATION");
               }}
-              onPendingTransaction={(hash) => {
+              onPendingTransaction={(hash, isMetaTx) => {
                 showModal("TRANSACTION_SUBMITTED", {
                   action: "Void",
                   txHash: hash
+                });
+                addPendingTransaction({
+                  type: subgraph.EventType.OfferVoided,
+                  hash,
+                  isMetaTx,
+                  accountType: "Seller",
+                  offer: {
+                    id: offer.id
+                  }
                 });
               }}
               onSuccess={handleSuccess}

--- a/src/components/transactions/PendingTransactions.tsx
+++ b/src/components/transactions/PendingTransactions.tsx
@@ -1,37 +1,14 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 import { usePendingTransactionsStore } from "../../lib/utils/hooks/transactions/usePendingTransactions";
 import { buildTableData } from "../../lib/utils/transactions";
-import { useCoreSDK } from "../../lib/utils/useCoreSdk";
 import Grid from "../ui/Grid";
 import Loading from "../ui/Loading";
 import TransactionsTable from "./TransactionsTable";
 
 export const PendingTransactions = () => {
-  const coreSDK = useCoreSDK();
-  const {
-    transactions,
-    reconcilePendingTransactions,
-    isLoading,
-    didInitiallyReconcile,
-    resetInitialReconcile
-  } = usePendingTransactionsStore();
-
-  useEffect(() => {
-    resetInitialReconcile();
-    reconcilePendingTransactions(coreSDK);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (didInitiallyReconcile) {
-      const intervalId = setInterval(() => {
-        reconcilePendingTransactions(coreSDK);
-      }, 5_000);
-      return () => clearInterval(intervalId);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [didInitiallyReconcile]);
+  const { transactions, isLoading, didInitiallyReconcile } =
+    usePendingTransactionsStore();
 
   const tableData = useMemo(() => buildTableData(transactions), [transactions]);
 

--- a/src/lib/utils/transactions.ts
+++ b/src/lib/utils/transactions.ts
@@ -91,22 +91,24 @@ export const buildTransactionLabelAndPath = (
         label: `Voided offer with id: ${offerId}`,
         pathname: offerPath
       };
-
     case subgraph.EventType.VoucherCanceled:
       return {
         label: `Canceled offer with id: ${offerId}`,
         pathname: offerPath
       };
-
     case subgraph.EventType.VoucherRedeemed:
       return {
         label: `Redeemed offer with id: ${offerId}`,
         pathname: offerPath
       };
-
     case subgraph.EventType.VoucherRevoked:
       return {
         label: `Revoked voucher with id: ${exchangeOrDisputeId}`,
+        pathname: exchangeOrDisputePath
+      };
+    case subgraph.EventType.VoucherExpired:
+      return {
+        label: `Expired voucher with id: ${exchangeOrDisputeId}`,
         pathname: exchangeOrDisputePath
       };
     case subgraph.EventType.SellerUpdated:


### PR DESCRIPTION
This PR integrates the previous work of the `useAddPendingTransaction` hook with the currently existing CTAs from the react-kit:
- commit
- complete
- expire
- void
- cancel
- redeem

This PR does not cover the other on-chain actions that do not use the react-kit components.