### PR TITLE
ci: move playwright postinstall to workflow

### DIFF
--- a/.github/workflows/ci_reusable.yaml
+++ b/.github/workflows/ci_reusable.yaml
@@ -123,6 +123,8 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
       - run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
       - run: npm run prettier
       - run: npm run lint
       - id: lint

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "coverage:report": "npm run coverage:unit",
     "upgrade:corec:latest": "npm install @bosonprotocol/common@latest @bosonprotocol/core-sdk@latest @bosonprotocol/ethers-sdk@latest @bosonprotocol/ipfs-storage@latest @bosonprotocol/react-kit@latest @bosonprotocol/widgets-sdk@latest",
     "upgrade:corec:alpha": "npm install @bosonprotocol/common@alpha @bosonprotocol/core-sdk@alpha @bosonprotocol/ethers-sdk@alpha @bosonprotocol/ipfs-storage@alpha @bosonprotocol/react-kit@alpha @bosonprotocol/widgets-sdk@alpha",
-    "postinstall": "npx playwright install --with-deps chromium",
     "generate": "graphql-codegen",
     "clean-react-cache": "run-script-os",
     "clean-react-cache:default": "rm -rf node_modules/.cache",


### PR DESCRIPTION
Cloudflare Pages seems to have problems with sudo privileges required by the postinall script / playwright. I moved it to the GHA workflow file for now.