### PR TITLE
fix: redemption export issue

### DIFF
--- a/src/components/seller/exchanges/SellerExchanges.tsx
+++ b/src/components/seller/exchanges/SellerExchanges.tsx
@@ -244,7 +244,7 @@ export default function SellerExchanges({
           buyerId: exchange.buyer.id,
           sellerId: exchange.seller.id
         };
-        const destinationAddressLowerCase = exchange?.offer.seller.operator;
+        const destinationAddressLowerCase = exchange?.buyer.wallet;
         const destinationAddress = utils.getAddress(
           destinationAddressLowerCase
         );


### PR DESCRIPTION
the redemption export was only including the delivery address for the exchanges where the buyer was also the seller (side effect), now it should work properly

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203473662036154