### PR TITLE
fix: prevent images which have ipfs://undefined in the src from showi…

### DIFF
--- a/src/components/ui/Image.tsx
+++ b/src/components/ui/Image.tsx
@@ -141,7 +141,12 @@ const Image: React.FC<IImage & React.HTMLAttributes<HTMLDivElement>> = ({
               handleSetStatus("error");
             } else {
               setDidOriginalSrcFail(true);
-              setCurrentSrc(getFallbackImageUrl(src, optimizationOpts));
+              const fallbackUrl = getFallbackImageUrl(src, optimizationOpts);
+              if (fallbackUrl.startsWith("unsafe:")) {
+                handleSetStatus("error");
+              } else {
+                setCurrentSrc(fallbackUrl);
+              }
             }
           }}
         />


### PR DESCRIPTION
…ng infinite loading spinner