### PR TITLE
fix: tabnapping protection

### DIFF
--- a/src/components/detail/DetailWidget/TokenGated.tsx
+++ b/src/components/detail/DetailWidget/TokenGated.tsx
@@ -7,6 +7,7 @@ import { CONFIG } from "../../../lib/config";
 import { colors } from "../../../lib/styles/colors";
 import { Offer } from "../../../lib/types/offer";
 import { IPrice } from "../../../lib/utils/convertPrice";
+import { sanitizeUrl } from "../../../lib/utils/url";
 import { useCoreSDK } from "../../../lib/utils/useCoreSdk";
 import { useConvertedPrice } from "../../price/useConvertedPrice";
 import Grid from "../../ui/Grid";
@@ -176,8 +177,9 @@ const TokenGated = ({
               </LockInfoDesc>
               <LockInfoDesc>
                 <a
-                  href={openseaLinkToOriginalMainnetCollection}
+                  href={sanitizeUrl(openseaLinkToOriginalMainnetCollection)}
                   target="_blank"
+                  rel="noopener noreferrer"
                 >
                   {openseaLinkToOriginalMainnetCollection}
                 </a>

--- a/src/components/disputeResolver/ManageDisputes/DisputesTable.tsx
+++ b/src/components/disputeResolver/ManageDisputes/DisputesTable.tsx
@@ -14,6 +14,7 @@ import copyToClipboard from "../../../lib/utils/copyToClipboard";
 import { getDateTimestamp } from "../../../lib/utils/getDateTimestamp";
 import { Disputes } from "../../../lib/utils/hooks/useExchanges";
 import { useKeepQueryParamsNavigate } from "../../../lib/utils/hooks/useKeepQueryParamsNavigate";
+import { sanitizeUrl } from "../../../lib/utils/url";
 import { useModal } from "../../modal/useModal";
 import Price from "../../price";
 import PaginationPages from "../../seller/common/PaginationPages";
@@ -175,7 +176,7 @@ export default function DisputesTable({ disputes }: Props) {
                     whiteSpace: "pre"
                   }}
                   onClick={() => {
-                    copyToClipboard(emailAddress).then(() => {
+                    copyToClipboard(sanitizeUrl(emailAddress)).then(() => {
                       toast(() => "Seller e-mail has been copied to clipboard");
                     });
                   }}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -5,6 +5,7 @@ import logo from "../../../src/assets/logo-white.svg";
 import { BosonRoutes } from "../../lib/routing/routes";
 import { breakpoint } from "../../lib/styles/breakpoint";
 import { useBreakpoints } from "../../lib/utils/hooks/useBreakpoints";
+import { sanitizeUrl } from "../../lib/utils/url";
 import SocialLogo, {
   SocialLogoValues
 } from "../../pages/custom-store/SocialLogo";
@@ -112,9 +113,9 @@ function Socials() {
       return socialMediaLinks.map(({ url, value }) => {
         return (
           <a
-            href={url}
+            href={sanitizeUrl(url)}
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
             key={`social_nav_${value}_${url}`}
           >
             <SocialLogo logo={value} />
@@ -241,9 +242,10 @@ export default function FooterComponent() {
                   return (
                     <a
                       key={`${footerLink.label}-${footerLink.value}-${index}`}
-                      href={footerLink.value}
+                      href={sanitizeUrl(footerLink.value)}
                       target="_blank"
                       style={{ textAlign: "center" }}
+                      rel="noopener noreferrer"
                     >
                       {footerLink.label}
                     </a>

--- a/src/components/toasts/SuccessTransactionToast.tsx
+++ b/src/components/toasts/SuccessTransactionToast.tsx
@@ -1,6 +1,7 @@
 import { Toast } from "react-hot-toast";
 
 import { colors } from "../../lib/styles/colors";
+import { sanitizeUrl } from "../../lib/utils/url";
 import Grid from "../ui/Grid";
 import Typography from "../ui/Typography";
 import SuccessToast from "./common/SuccessToast";
@@ -33,7 +34,7 @@ export default function SuccessTransactionToast({
             View details
           </Typography>
         ) : url ? (
-          <a href={url} target="_blank">
+          <a href={sanitizeUrl(url)} target="_blank" rel="noopener noreferrer">
             <Typography color={colors.secondary}>View details</Typography>
           </a>
         ) : null}

--- a/src/pages/profile/seller/SellerSocial.tsx
+++ b/src/pages/profile/seller/SellerSocial.tsx
@@ -7,6 +7,7 @@ import {
   Profile,
   ProfileFieldsFragment
 } from "../../../lib/utils/hooks/lens/graphql/generated";
+import { sanitizeUrl } from "../../../lib/utils/url";
 import { preAppendHttps } from "../../../lib/validation/regex/url";
 import {
   DetailShareWrapper,
@@ -26,7 +27,12 @@ function RenderSocial({
   icon: Icon
 }: RenderSocialProps) {
   return (
-    <SocialIcon href={href} $isDisabled={disabled} target="_blank">
+    <SocialIcon
+      href={href}
+      $isDisabled={disabled}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       {Icon ? Icon : <Globe size={24} />}
     </SocialIcon>
   );
@@ -60,7 +66,7 @@ export default function SellerSocial({
       {/* TODO: Removed as we don't have discord in lens profile */}
       {/* <RenderSocial icon={DiscordLogo} href={""} /> */}
       {lensUrl !== false && (
-        <RenderSocial icon={<Globe size={24} />} href={lensUrl} />
+        <RenderSocial icon={<Globe size={24} />} href={sanitizeUrl(lensUrl)} />
       )}
       <DetailShareWrapper>
         <DetailShare />


### PR DESCRIPTION
fix #592 
- URL is sanitize before setting the "`href`" field. Applied to:
    - socialMediaLinks
    - additionalFooterLinks
    - openseaLinkToOriginalMainnetCollection
    - seller contactLinks email (only used for Dispute Resolver module)
    - seller lensUrl
    - openseaLinkToOriginalMainnetCollection (in case of Token-gated offer and commitProxyAddress is used)
    - SuccessTransactionToast.url, as a precaution, as this component is used in many different contexts
- ensure the options `rel="noopener noreferrer"` are set. Applied to:
    - socialMediaLinks
    - additionalFooterLinks
    - seller lensUrl
    - openseaLinkToOriginalMainnetCollection (in case of Token-gated offer and commitProxyAddress is used)
    - SuccessTransactionToast.url, as a precaution, as this component is used in many different contexts

Can be tested with the following URL:
- http://localhost:3333/#/?isCustomStoreFront=true&socialMediaLinks=[{"value"%3A"facebook"%2C"url"%3A"javascript:alert(1)"}]
- http://localhost:3333/#/?isCustomStoreFront=true&additionalFooterLinks=[{%22label%22%3A%22xxx%22%2C%22value%22%3A%22javascript:alert(1)%22}]
- http://localhost:3333/#/products/ede57c-6ad-621-0d1c-434ef1525a2a?isCustomStoreFront=true&commitProxyAddress=0x0000000000000000000000000000000000000000&openseaLinkToOriginalMainnetCollection=javascript:alert(1) (product UUID `ede57c-6ad-621-0d1c-434ef1525a2a` only valid on staging environment)
