### PR TITLE
fix: ignore missing source map warnings in Webpack compilation step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ REACT_APP_META_TX_API_KEY_MAP={"testing-80001-0":"xxxxxx", "testing-5-0":"xxxxxx
 
 # Biconomy API ids can be set here, to allow meta transactions to the protocol contracts
 # As each contracts needs its own AipId, we need to consider protocol, and all supported ERC20 tokens
-REACT_APP_META_TX_API_IDS_MAP={"testing-80001-0":{"protocol": "xxxxxx", "BOSON": "yyyyyy", "WETH", "zzzzzz"}, "testing-5-0":{"protocol": "xxxxxx", "BOSON": "yyyyyy", "WETH", "zzzzzz"}}
+REACT_APP_META_TX_API_IDS_MAP={"testing-80001-0":{"protocol": "xxxxxx", "BOSON": "yyyyyy", "WETH": "zzzzzz"}, "testing-5-0":{"protocol": "xxxxxx", "BOSON": "yyyyyy", "WETH": "zzzzzz"}}
 
 # Comma-separated default list of offer IDs that are shown in the app
 REACT_APP_OFFER_CURATION_LIST=

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -18,4 +18,4 @@ jobs:
         with:
           requireScope: false
           subjectPattern: ^(?![A-Z]).+$
-          validateSingleCommit: true
+          validateSingleCommit: false

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -31,6 +31,8 @@ module.exports = {
         util: require.resolve("util/")
       };
 
+      config.ignoreWarnings = [/Failed to parse source map/];
+
       return config;
     },
     addWebpackResolve({

--- a/package-lock.json
+++ b/package-lock.json
@@ -40522,6 +40522,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-scripts/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-scripts/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -40534,6 +40545,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-scripts/node_modules/source-map-loader": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.2.tgz",
+      "integrity": "sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==",
+      "dependencies": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/react-select": {
@@ -42370,35 +42401,6 @@
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-loader": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.5",
-        "iconv-lite": "^0.6.3",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/source-map-loader/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -73938,12 +73940,30 @@
         "camelcase": {
           "version": "6.3.0"
         },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "source-map-loader": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.2.tgz",
+          "integrity": "sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==",
+          "requires": {
+            "abab": "^2.0.5",
+            "iconv-lite": "^0.6.3",
+            "source-map-js": "^1.0.1"
           }
         }
       }
@@ -75234,22 +75254,6 @@
     },
     "source-map-js": {
       "version": "1.0.2"
-    },
-    "source-map-loader": {
-      "version": "3.0.1",
-      "requires": {
-        "abab": "^2.0.5",
-        "iconv-lite": "^0.6.3",
-        "source-map-js": "^1.0.1"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "source-map-resolve": {
       "version": "0.6.0",


### PR DESCRIPTION
In react scripts v5 and above warnings are being emitted for missing source-maps in node module dependencies. Due to this change there is significantly more noise in the terminal which can lead to us missing more important warnings.

This commit:
 - Configures our Webpack to ignore the source map warning.
 - Fixes the syntax for a default environment variable which was injecting incorrectly formatted json to be read.

Before: 
<img width="1726" alt="Pasted Graphic 4" src="https://github.com/bosonprotocol/interface/assets/5686659/4c246a87-5004-4d1f-be1e-131851ab2998">

After: 
<img width="1714" alt="Pasted Graphic 5" src="https://github.com/bosonprotocol/interface/assets/5686659/6b3a646f-ba27-489a-ad5b-e97cd25d233b">

