### PR TITLE
fix: redemption duration cannot be 0 for offers with no expiration date

### DIFF
--- a/src/components/product/utils/validationSchema.ts
+++ b/src/components/product/utils/validationSchema.ts
@@ -230,15 +230,7 @@ export const commonCoreTermsOfSaleValidationSchema = {
     then: () => {
       return Yup.number()
         .required(validationMessage.required)
-        .min(0, "It cannot be negative")
-        .test({
-          message:
-            "It cannot be 0 if the redemption from date is not specified",
-          test: function (value, context) {
-            const { redemptionPeriod } = context.parent;
-            return redemptionPeriod ? true : value !== 0;
-          }
-        });
+        .min(1, "It has to be 1 at least");
     },
     otherwise: Yup.number().min(0, "It must be 0").max(0, "It must be 0")
   })


### PR DESCRIPTION
offers with no expiration date should always have a redemption duration of at least 1

![image](https://github.com/bosonprotocol/interface/assets/102516373/26fad33b-4629-400f-a34c-4be91b5db950)


this validation was already implemented in core components but not in the dapp

fixes: https://github.com/bosonprotocol/interface/issues/1023