### PR TITLE
feat: allow to premint and create listing for an existing product

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "crypto-browserify": "^3.12.0",
         "dayjs": "^1.11.3",
         "ethers": "^5.7.0",
+        "ethers-v6": "npm:ethers@^6.10.0",
         "fetch": "^1.1.0",
         "formik": "^2.2.9",
         "graphql": "^16.5.0",
@@ -22977,6 +22978,64 @@
         "@ethersproject/wallet": "5.7.0",
         "@ethersproject/web": "5.7.1",
         "@ethersproject/wordlists": "5.7.0"
+      }
+    },
+    "node_modules/ethers-v6": {
+      "name": "ethers",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.10.0.tgz",
+      "integrity": "sha512-nMNwYHzs6V1FR3Y4cdfxSQmNgZsRj1RiTU25JwvnJLmyzw9z3SKxNc2XKDuiXXo/v9ds5Mp9m6HBabgYQQ26tA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers-v6/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/ethers-v6/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/ethers-v6/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/ethjs-unit": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "crypto-browserify": "^3.12.0",
     "dayjs": "^1.11.3",
     "ethers": "^5.7.0",
+    "ethers-v6": "npm:ethers@^6.10.0",
     "fetch": "^1.1.0",
     "formik": "^2.2.9",
     "graphql": "^16.5.0",

--- a/src/components/seller/products/SellerProductsTable.tsx
+++ b/src/components/seller/products/SellerProductsTable.tsx
@@ -594,8 +594,7 @@ export default function SellerProductsTable({
                         </Typography>
                       ),
                       action: !(
-                        variantStatus === OffersKit.OfferState.VOIDED ||
-                        variant?.quantityAvailable === "0"
+                        variantStatus === OffersKit.OfferState.VOIDED
                       ) && (
                         <Grid justifyContent="flex-end">
                           <VoidButton
@@ -608,7 +607,7 @@ export default function SellerProductsTable({
                                 showModal(
                                   modalTypes.VOID_PRODUCT,
                                   {
-                                    title: "Void Confirmation",
+                                    title: "Premint Confirmation",
                                     offerId: variant.id,
                                     offer: variant as Offer,
                                     refetch
@@ -618,7 +617,7 @@ export default function SellerProductsTable({
                               }
                             }}
                           >
-                            Void
+                            Premint
                           </VoidButton>
                         </Grid>
                       )
@@ -762,10 +761,7 @@ export default function SellerProductsTable({
               );
             })(),
             action: (() => {
-              const withVoidButton = !(
-                status === OffersKit.OfferState.VOIDED ||
-                offer?.quantityAvailable === "0"
-              );
+              const withVoidButton = !(status === OffersKit.OfferState.VOIDED);
               return (
                 <Grid gap="1rem" justifyContent="flex-end">
                   <Actions
@@ -786,7 +782,7 @@ export default function SellerProductsTable({
                                         showModal(
                                           modalTypes.VOID_PRODUCT,
                                           {
-                                            title: "Void Confirmation",
+                                            title: "Premint Confirmation",
                                             offers:
                                               offer.additional?.variants.filter(
                                                 (variant) => {
@@ -808,7 +804,7 @@ export default function SellerProductsTable({
                                         showModal(
                                           modalTypes.VOID_PRODUCT,
                                           {
-                                            title: "Void Confirmation",
+                                            title: "Premint Confirmation",
                                             offerId: offer.id,
                                             offer,
                                             refetch
@@ -819,7 +815,7 @@ export default function SellerProductsTable({
                                     }
                                   }}
                                 >
-                                  Void
+                                  Premint
                                 </UnthemedButton>
                               )
                             }


### PR DESCRIPTION
relates to https://github.com/bosonprotocol/core-components/pull/774

NOTE: the draft version replaces the Void Product popup dialog to integrate Premint and CreateListing commands

===

TODO: 
- create specific popup dialog to Premint vouchers (with UI allowing the user to set the number of vouchers to reserve/premint)
- create specific popup dialog to List vouchers (with UI allowing the user to select the tokenId amongst the preminted vouchers that are still owned by the seller)