### PR TITLE
chore: upgrade the core-components dependency to run with 0xgraph-hos…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.8.1",
         "@bosonprotocol/chat-sdk": "^1.3.1-alpha.9",
-        "@bosonprotocol/react-kit": "^0.34.0-alpha.23",
+        "@bosonprotocol/react-kit": "^0.34.0",
         "@davatar/react": "^1.10.4",
         "@ethersproject/address": "^5.6.1",
         "@ethersproject/units": "^5.7.0",
@@ -2488,9 +2488,10 @@
       }
     },
     "node_modules/@bosonprotocol/common": {
-      "version": "1.29.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/common/-/common-1.29.0-alpha.11.tgz",
-      "integrity": "sha512-JjcCkQmvbkPuKi2Z+fquX/UWOEkL9YZTGn19XbPHUFq8Saz6i1OQC+3ArQ2ZyeRSfVx03yrZwcMiY5QdQfTKbg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/common/-/common-1.29.0.tgz",
+      "integrity": "sha512-TlRucPiPXrqgSEAgz6dwlArdkPO2HZcgnZan3IJo5x58YM0QbxMtvdPseUIpOwgkIF9vEE8346tYiA+CdrXyZw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bosonprotocol/metadata": "^1.16.2",
         "@ethersproject/abi": "^5.5.0",
@@ -2502,11 +2503,12 @@
       }
     },
     "node_modules/@bosonprotocol/core-sdk": {
-      "version": "1.41.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/core-sdk/-/core-sdk-1.41.0-alpha.25.tgz",
-      "integrity": "sha512-g9kEz9n2SZ+y/QdRRE/coPdivcDPi5+TtAgNITMbAQXSotpJLGvPRieteCUSgQpnlH96BVEmMbSCj8BoI3TfMg==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/core-sdk/-/core-sdk-1.41.0.tgz",
+      "integrity": "sha512-3qYW3j+bsAVv3necppqFtRBhtg3m8po25UVJ6Btq8G1o05YSqt5eiGrX6SWWlWXjw2XSsju29rR9oSpqyu0HKg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/common": "^1.29.0-alpha.11",
+        "@bosonprotocol/common": "^1.29.0",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
@@ -2523,20 +2525,22 @@
       }
     },
     "node_modules/@bosonprotocol/ethers-sdk": {
-      "version": "1.15.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/ethers-sdk/-/ethers-sdk-1.15.0-alpha.11.tgz",
-      "integrity": "sha512-fCKBsVmQKbPK5kFq5mCtdIGS8tWGmfZE/8frjP5J7PV1RjUriBZ47xiu0S19EKBJCNWP+RM9c8aJYKv3oO2WIA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/ethers-sdk/-/ethers-sdk-1.15.0.tgz",
+      "integrity": "sha512-Ceg9iNyJV9Ppe/xtPbaWko8MqwebckNxo2Nou/kvjun+LXfwXi/xK5WzjWAvRqcqk+exy7qxbKC+Zw8Sp93PKQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@bosonprotocol/common": "^1.29.0-alpha.11"
+        "@bosonprotocol/common": "^1.29.0"
       },
       "peerDependencies": {
         "ethers": "^5.5.0"
       }
     },
     "node_modules/@bosonprotocol/ipfs-storage": {
-      "version": "1.12.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/ipfs-storage/-/ipfs-storage-1.12.0-alpha.23.tgz",
-      "integrity": "sha512-SQXXX9OAP2XQ0esG50tG//hNjXvXK4zVNP2R6v6BOve3loP8WhA/7juWjuCl3rE+nuGgr6lEgEZkG9rgr5ZPYw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/ipfs-storage/-/ipfs-storage-1.12.0.tgz",
+      "integrity": "sha512-8aD4F3jsy/XoVkuIusQq37wTYr/XiffknUBMw8iv6DAldLUlofRL6DrYSAQ9wULqRvmAYnmi7ApCJT+BHeZV4Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bosonprotocol/metadata-storage": "^1.0.1",
         "ipfs-http-client": "^56.0.1",
@@ -2548,6 +2552,7 @@
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/@bosonprotocol/metadata/-/metadata-1.16.2.tgz",
       "integrity": "sha512-yA99IO+BHvc3AkCba/fsrrXr3npb7zxwPvz8PUJ9qrKd7Gid95hE5V5sG9tpbeNc/UuErQ3wX8G5pmitVNlaIQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bosonprotocol/metadata-storage": "^1.0.1",
         "schema-to-yup": "^1.11.11"
@@ -2556,17 +2561,19 @@
     "node_modules/@bosonprotocol/metadata-storage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@bosonprotocol/metadata-storage/-/metadata-storage-1.0.1.tgz",
-      "integrity": "sha512-f2W2SQAvY5IKD6L9JwaiNye7gGRIIPd/HOB0i+otWLzMPBlwQtbN4JeWSuKeJvuaqu8tyMy7CHzN8EkhrJDB+A=="
+      "integrity": "sha512-f2W2SQAvY5IKD6L9JwaiNye7gGRIIPd/HOB0i+otWLzMPBlwQtbN4JeWSuKeJvuaqu8tyMy7CHzN8EkhrJDB+A==",
+      "license": "Apache-2.0"
     },
     "node_modules/@bosonprotocol/react-kit": {
-      "version": "0.34.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/react-kit/-/react-kit-0.34.0-alpha.23.tgz",
-      "integrity": "sha512-sQWlnPVdZ2/YYE/kjKl5m7nJpiZTYl7uvPc7kXURCbwMIeD/5nL5fRCpRDsxH7ZmR5doCsSUKLG1xIXT/pTKLw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/react-kit/-/react-kit-0.34.0.tgz",
+      "integrity": "sha512-Smf6kplGcCT0E7UYq+oI1pnQqhguecNnITbToQ09MKiOOo9Idklo6Xe2BhHLuYxKyakGNmTevKh0/zuDz7Yc4A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bosonprotocol/chat-sdk": "^1.3.1-alpha.9",
-        "@bosonprotocol/core-sdk": "^1.41.0-alpha.25",
-        "@bosonprotocol/ethers-sdk": "^1.15.0-alpha.11",
-        "@bosonprotocol/ipfs-storage": "^1.12.0-alpha.23",
+        "@bosonprotocol/core-sdk": "^1.41.0",
+        "@bosonprotocol/ethers-sdk": "^1.15.0",
+        "@bosonprotocol/ipfs-storage": "^1.12.0",
         "@davatar/react": "1.11.1",
         "@ethersproject/units": "5.6.0",
         "@glidejs/glide": "3.6.0",
@@ -6473,6 +6480,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz",
       "integrity": "sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==",
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "cborg": "^1.6.0",
         "multiformats": "^9.5.4"
@@ -6482,6 +6490,7 @@
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.11.tgz",
       "integrity": "sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==",
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "cborg": "^1.5.4",
         "multiformats": "^9.5.4"
@@ -6491,6 +6500,7 @@
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.18.tgz",
       "integrity": "sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==",
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "multiformats": "^9.5.4"
       }
@@ -9008,6 +9018,7 @@
       "resolved": "https://registry.npmjs.org/@opensea/seaport-js/-/seaport-js-4.0.4.tgz",
       "integrity": "sha512-pOBgU+y1H9Bh463ZdgFshFBxnBQvEaGfoOJFDHbkvZTNLSqIOyuDmICFTQJEiPjYsS6tMQTbw2oJBtcVLFUT2g==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "ethers": "^6.9.0",
         "merkletreejs": "^0.4.0"
@@ -9019,12 +9030,14 @@
     "node_modules/@opensea/seaport-js/node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
     },
     "node_modules/@opensea/seaport-js/node_modules/@types/node": {
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -9032,7 +9045,8 @@
     "node_modules/@opensea/seaport-js/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/@opensea/seaport-js/node_modules/ethers": {
       "version": "6.13.4",
@@ -9048,6 +9062,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -9064,12 +9079,14 @@
     "node_modules/@opensea/seaport-js/node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
     },
     "node_modules/@opensea/seaport-js/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14226,7 +14243,8 @@
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
     },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
@@ -17171,7 +17189,8 @@
     "node_modules/any-signal": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
-      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==",
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -18197,6 +18216,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
       "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
+      "license": "ISC",
       "dependencies": {
         "browser-readablestream-to-it": "^1.0.3"
       }
@@ -18379,7 +18399,8 @@
     "node_modules/browser-readablestream-to-it": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
-      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
+      "license": "ISC"
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -18561,7 +18582,8 @@
     "node_modules/buffer-reverse": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
-      "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg=="
+      "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==",
+      "license": "MIT"
     },
     "node_modules/buffer-to-arraybuffer": {
       "version": "0.0.5",
@@ -18820,6 +18842,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.2.tgz",
       "integrity": "sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==",
+      "license": "Apache-2.0",
       "bin": {
         "cborg": "cli.js"
       }
@@ -20223,7 +20246,8 @@
     "node_modules/crypto-js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -20636,6 +20660,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-1.0.0.tgz",
       "integrity": "sha512-U0b/YsIPBp6YZNTFrVjwLZAlY3qGRxZTIEcM/CcQmrVrCWq9MWQq9pheXVSPLIhF4SNwzp2SikPva4/BIrJY+g==",
+      "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.3",
         "multiformats": "^9.0.2"
@@ -20645,6 +20670,7 @@
       "version": "6.0.15",
       "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.15.tgz",
       "integrity": "sha512-Vm3VTSTwlmGV92a3C5aeY+r2A18zbH2amehNhsX8PBa3muXICaWrN8Uri85A5hLH7D7ElhE8PdjxD6kNqUmTZA==",
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "cborg": "^1.5.4",
         "multiformats": "^9.5.4"
@@ -20669,6 +20695,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
       "integrity": "sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -26300,6 +26327,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
       "integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
+      "license": "MIT",
       "dependencies": {
         "interface-store": "^2.0.2",
         "nanoid": "^3.0.2",
@@ -26309,7 +26337,8 @@
     "node_modules/interface-store": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
-      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==",
+      "license": "(Apache-2.0 OR MIT)"
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -26389,6 +26418,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.10.3.tgz",
       "integrity": "sha512-GNid2lRBjR5qgScCglgk7w9Hk3TZAwPHQXxOLQx72wgyc0jF2U5NXRoKW0GRvX8NPbHmsrFszForIqxd23I1Gw==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/dag-pb": "^2.1.3",
         "interface-datastore": "^6.0.2",
@@ -26402,6 +26432,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.14.3.tgz",
       "integrity": "sha512-aBkewVhgAj3NWXPwu6imj0wADGiGVZmJzqKzODOJsibDjkx6FGdMv8kvvqtLnK8LS/dvSk9yk32IDtuDyYoV7Q==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "license": "MIT",
       "dependencies": {
         "any-signal": "^3.0.0",
         "blob-to-it": "^1.0.1",
@@ -26430,6 +26461,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-56.0.3.tgz",
       "integrity": "sha512-E3L5ylVl6BjyRUsNehvfuRBYp1hj8vQ8in4zskVPMNzXs6JiCFUbif5a6BtcAlSK4xPQyJCeLNNAWLUeFQTLNA==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/dag-cbor": "^7.0.0",
         "@ipld/dag-json": "^8.0.1",
@@ -26459,6 +26491,7 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz",
       "integrity": "sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
@@ -26472,6 +26505,7 @@
       "version": "9.0.14",
       "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
       "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "any-signal": "^3.0.0",
         "browser-readablestream-to-it": "^1.0.0",
@@ -26499,6 +26533,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -27515,12 +27550,14 @@
     "node_modules/it-first": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
-      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g==",
+      "license": "ISC"
     },
     "node_modules/it-glob": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
       "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "license": "ISC",
       "dependencies": {
         "@types/minimatch": "^3.0.4",
         "minimatch": "^3.0.4"
@@ -27537,7 +27574,8 @@
     "node_modules/it-peekable": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
-      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
+      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ==",
+      "license": "ISC"
     },
     "node_modules/it-reader": {
       "version": "2.1.0",
@@ -31336,7 +31374,8 @@
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.0.1",
@@ -31763,6 +31802,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/merkletreejs/-/merkletreejs-0.4.0.tgz",
       "integrity": "sha512-a48Ta5kWiVNBgeEbZVMm6FB1hBlp6vEuou/XnZdlkmd2zq6NZR6Sh2j+kR1B0iOZIXrTMcigBYzZ39MLdYhm1g==",
+      "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.1",
         "buffer-reverse": "^1.0.1",
@@ -33918,6 +33958,7 @@
       "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
       "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
       "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
+      "license": "MIT",
       "dependencies": {
         "dns-over-http-resolver": "^1.2.3",
         "err-code": "^3.0.1",
@@ -33932,6 +33973,7 @@
       "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
       "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
       "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr-to-uri",
+      "license": "MIT",
       "dependencies": {
         "multiaddr": "^10.0.0"
       }
@@ -34062,6 +34104,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -37073,10 +37116,11 @@
       }
     },
     "node_modules/opensea-js": {
-      "version": "7.1.13",
-      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.13.tgz",
-      "integrity": "sha512-IwyBeGU/W6dBG3HCopzq1UdTXkxuIK9aWqucXFy6VUUxZQBKFbssX0OgkHl9RO6udHLC9Y9GG3HqSYDBfEiD7A==",
+      "version": "7.1.14",
+      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.14.tgz",
+      "integrity": "sha512-CePsccXrtXfxe1vFOOLHuVfoHwgqOhCdvQBZydrl/et/cOP84b97x8iaf4ikjBojUXN1VqPPDx1d/q1Wb+6x8g==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@opensea/seaport-js": "^4.0.0",
         "ethers": "^6.9.0"
@@ -37088,12 +37132,14 @@
     "node_modules/opensea-js/node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
     },
     "node_modules/opensea-js/node_modules/@types/node": {
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -37101,7 +37147,8 @@
     "node_modules/opensea-js/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/opensea-js/node_modules/ethers": {
       "version": "6.13.4",
@@ -37117,6 +37164,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -37133,12 +37181,14 @@
     "node_modules/opensea-js/node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
     },
     "node_modules/opensea-js/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -37399,7 +37449,8 @@
     "node_modules/parse-duration": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
-      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ==",
+      "license": "MIT"
     },
     "node_modules/parse-filepath": {
       "version": "1.0.2",
@@ -39039,6 +39090,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
       "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -39842,6 +39894,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-3.0.0.tgz",
       "integrity": "sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==",
+      "license": "MIT",
       "dependencies": {
         "p-defer": "^3.0.0"
       }
@@ -41436,7 +41489,8 @@
     "node_modules/retimer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
-      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -41825,6 +41879,7 @@
       "version": "1.12.18",
       "resolved": "https://registry.npmjs.org/schema-to-yup/-/schema-to-yup-1.12.18.tgz",
       "integrity": "sha512-rzMtnIQpkokOzyb6JfsuCB+/BklFB5J7pFcvc/SnybOtmks8uW4SJXfMpzMQT98f826XgI3/mlPGQf0HBhF8FQ==",
+      "license": "MIT",
       "dependencies": {
         "dashify": "^2.0.0",
         "uniq": "^1.0.1",
@@ -41836,6 +41891,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"
       },
@@ -41847,6 +41903,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/yup/-/yup-1.4.0.tgz",
       "integrity": "sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==",
+      "license": "MIT",
       "dependencies": {
         "property-expr": "^2.0.5",
         "tiny-case": "^1.0.3",
@@ -43522,6 +43579,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
       "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
+      "license": "MIT",
       "dependencies": {
         "retimer": "^3.0.0"
       }
@@ -43529,7 +43587,8 @@
     "node_modules/tiny-case": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
-      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
@@ -43642,6 +43701,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
       "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -44300,7 +44360,8 @@
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "1.9.0",
@@ -44389,7 +44450,8 @@
     "node_modules/uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA=="
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
+      "license": "MIT"
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
@@ -44692,6 +44754,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/uppercamelcase/-/uppercamelcase-3.0.0.tgz",
       "integrity": "sha512-zTWmRiOJACCdFGWjzye3L5cjSuVdZ/c8C0iHIwVbfORFD8IhGNAO6BOWkZ+fj+SI6/aFbdjGXE6gwPG780H4gQ==",
+      "license": "MIT",
       "dependencies": {
         "camelcase": "^4.1.0"
       },
@@ -44703,6 +44766,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@apollo/client": "^3.8.1",
     "@bosonprotocol/chat-sdk": "^1.3.1-alpha.9",
-    "@bosonprotocol/react-kit": "^0.34.0-alpha.23",
+    "@bosonprotocol/react-kit": "^0.34.0",
     "@davatar/react": "^1.10.4",
     "@ethersproject/address": "^5.6.1",
     "@ethersproject/units": "^5.7.0",


### PR DESCRIPTION
…ted subgraphs

related to https://github.com/bosonprotocol/core-components/pull/784
Subgraphs are now:
- TESTING;
  - https://api.0xgraph.xyz/api/public/c56471f5-5b1d-4a62-b1de-450044cb7ebc/subgraphs/boson-testing-sepolia/latest/gn
  - https://api.0xgraph.xyz/api/public/c56471f5-5b1d-4a62-b1de-450044cb7ebc/subgraphs/boson-testing-amoy/latest/gn
- STAGING:
  - https://api.0xgraph.xyz/api/public/da9367fc-3453-4e08-824f-19fb4281b6a1/subgraphs/boson-staging-sepolia/latest/gn
  - https://api.0xgraph.xyz/api/public/da9367fc-3453-4e08-824f-19fb4281b6a1/subgraphs/boson-staging-amoy/latest/gn
- PRODUCTION:
  - https://api.0xgraph.xyz/api/public/b521f6b7-36c4-4117-8ad5-6b21c6eeb195/subgraphs/boson-ethereum/latest/gn
  - https://api.0xgraph.xyz/api/public/b521f6b7-36c4-4117-8ad5-6b21c6eeb195/subgraphs/boson-polygon/latest/gn