### PR TITLE
ci: add Jekyll GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./docs
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This workflow automates the building and deployment of a Jekyll site to GitHub Pages, including steps for checking out the code, building the site, and deploying it.