### PR TITLE
feat: default the dapp to Base instead of Polygon

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -100,7 +100,23 @@ export const envConfigsFilteredByEnv: ProtocolConfig[] = getEnvConfigs(envName);
 export const envChainIds = envConfigsFilteredByEnv.map(
   (envConf) => envConf.chainId
 );
-export const defaultEnvConfig: ProtocolConfig = envConfigsFilteredByEnv[0];
+
+// Chain the dapp starts on, per environment. getEnvConfigs() lists the Polygon
+// config first, so without this the app would default to Polygon (Amoy on
+// testing/staging). Chain ids are hardcoded rather than imported from
+// lib/constants/chains to avoid a circular import (that module reads
+// envChainIds from here).
+const defaultChainIdPerEnv: Record<EnvironmentType, number> = {
+  local: 31337, // Local Hardhat
+  testing: 84532, // Base Sepolia
+  staging: 84532, // Base Sepolia
+  production: 8453 // Base
+};
+
+export const defaultEnvConfig: ProtocolConfig =
+  envConfigsFilteredByEnv.find(
+    (envConf) => envConf.chainId === defaultChainIdPerEnv[envName]
+  ) ?? envConfigsFilteredByEnv[0];
 export const defaultChainId = defaultEnvConfig.chainId;
 
 export const CONFIG = {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -97,6 +97,11 @@ function getMetaTxApiKey(envConfig: ProtocolConfig) {
 }
 
 export const envConfigsFilteredByEnv: ProtocolConfig[] = getEnvConfigs(envName);
+if (!envConfigsFilteredByEnv.length) {
+  // Fail fast with context: everything below assumes at least one config, and
+  // without this the app would crash later on an undefined defaultEnvConfig.
+  throw new Error(`No protocol config is available for envName ${envName}`);
+}
 export const envChainIds = envConfigsFilteredByEnv.map(
   (envConf) => envConf.chainId
 );


### PR DESCRIPTION
## What

On startup the dapp defaulted to Polygon — Amoy on testing/staging — because `getEnvConfigs()` lists the Polygon config first for every environment and `defaultEnvConfig` was simply `envConfigsFilteredByEnv[0]`.

This picks the default config by an explicit per-environment chain id instead:

| env | default chain |
| --- | --- |
| local | 31337 (local Hardhat) |
| testing | 84532 (Base Sepolia) |
| staging | 84532 (Base Sepolia) |
| production | 8453 (Base) |

It falls back to the first config if the preferred chain is not part of the environment, so the app can't fail to boot on a config list that drops Base.

## Why it covers the whole startup path

`defaultEnvConfig` and the `defaultChainId` derived from it feed:

- the initial `ConfigProvider` state (and therefore the Magic provider's chain),
- the `Network` connector's `defaultChainId`,
- WalletConnect v2's default chain,
- the Coinbase Wallet connector's RPC url.

All of them move to Base with this one change. RPC urls and `RPC_PROVIDERS` entries already exist for both 84532 and 8453, and `ChainId_BASE_SEPOLIA` / `ChainId.BASE` are already in `SUPPORTED_CHAINS`, so no other wiring was needed.

Chain ids are hardcoded rather than imported from `lib/constants/chains` because that module reads `envChainIds` from `lib/config` — importing back would create a cycle.

## Testing

- `npx tsc --noEmit` — clean.
- `eslint src/lib/config.ts` — clean.
- Resolved the config for each env against the installed `@bosonprotocol/common`: `local-31337-0`, `testing-84532-0`, `staging-84532-0`, `production-8453-0`.

## Note for reviewers

Meta-transaction config is keyed by `configId`. `staging-84532-0` has no entry in the local `.env` maps (`testing-84532-0` does). The deployed values come from the `REACT_APP_META_TX_API_KEY_MAP` / `REACT_APP_META_TX_API_IDS_MAP` GitHub secrets, so please check those cover Base before this reaches staging — otherwise staging loses meta-tx on the new default chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
